### PR TITLE
[Bug-Fix] webhook dispatch always returns array of rows and warn on empty HTTP response (ODS-11188)

### DIFF
--- a/src/Services/DispatchWorkflowService.php
+++ b/src/Services/DispatchWorkflowService.php
@@ -575,7 +575,9 @@ class DispatchWorkflowService
         }
 
         if (! $totalPayloadToGenerate) {
-            return $parsedData;
+            // All values are scalars wrap so callers always get an array-of-rows,
+            // consistent with the multi-value path below.
+            return [$parsedData];
         }
 
         $payload = [];

--- a/src/Services/WorkflowActions/Helpers/Http.php
+++ b/src/Services/WorkflowActions/Helpers/Http.php
@@ -4,6 +4,7 @@ namespace Taurus\Workflow\Services\WorkflowActions\Helpers;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
+use Illuminate\Support\Facades\Log;
 
 class Http
 {
@@ -27,8 +28,8 @@ class Http
         $options = ['headers' => $headers];
 
         if (config('app.env') != 'production') {
-            \Log::info('WORKFLOW - Request header.', $headers);
-            \Log::info('WORKFLOW - Request body.', $body);
+            Log::info('WORKFLOW - Request header.', $headers);
+            Log::info('WORKFLOW - Request body.', $body);
         }
 
         $contentType = strtolower($headers['Content-Type']);
@@ -46,10 +47,16 @@ class Http
         try {
             $response = $client->request($method, $url, $options);
 
-            \Log::info('WORKFLOW - Response status code: '.$response->getStatusCode());
-            \Log::info('WORKFLOW - Response ', json_decode($response->getBody(), true));
+            $responseBody = json_decode($response->getBody(), true);
 
-            return json_decode($response->getBody(), true);
+            Log::info('WORKFLOW - Response status code: '.$response->getStatusCode());
+            if ($responseBody === null) {
+                Log::warning('WORKFLOW - Response body is empty or not valid JSON.');
+            } else {
+                Log::info('WORKFLOW - Response ', $responseBody);
+            }
+
+            return $responseBody;
         } catch (RequestException $e) {
             throw new \Exception('HTTP Request failed: '.$e->getMessage());
         }

--- a/src/Services/WorkflowActions/WebhookAction.php
+++ b/src/Services/WorkflowActions/WebhookAction.php
@@ -76,22 +76,20 @@ class WebhookAction extends AbstractWorkflowAction
      */
     public function getListOfRequiredData()
     {
-        // TODO: Need to come from DB. HARDCODED for farmers release
-        return [
-            'Type',
-            'DueDate',
-            'SubType',
-            'ReasonCode',
-            'CreatedAt',
-            'Task',
-            'DocumentName',
-            'PolicyNumber',
-            'SourceSystem',
-            'WyoAgencyAgentCode',
-            'PremiumDue',
-            'PremiumCapDiscountAmount',
-            'PolicyNumberWithoutPrefix',
+        $payload = $this->getPayload();
+        $searchIn = [
+            $payload['webhookRequestPayload'] ?? [],
+            $payload['webhookRequestHeaders'] ?? [],
+            $payload['webhookRequestUrl'] ?? '',
         ];
+
+        $placeholders = [];
+        array_walk_recursive($searchIn, function ($value) use (&$placeholders) {
+            preg_match_all('/{{\s*(.*?)\s*}}/', $value ?? '', $matches);
+            $placeholders = array_merge($placeholders, $matches[1]);
+        });
+
+        return array_unique($placeholders);
     }
 
     /**


### PR DESCRIPTION
# Description
1. webhook dispatch always returns array-of-rows, avoiding errors when all placeholder values are scalar
2. warn on empty or non-JSON HTTP response body instead of crashing `Log::info` with null

# Context
https://taurus-llc.atlassian.net/browse/ODS-11188

# Testing Done
Local

# DB Changes
None