### PR TITLE
[Feature] Add CC and BCC Support In Email Configuration In Workflow (ODS-11522)

### DIFF
--- a/src/Jobs/EmailJob.php
+++ b/src/Jobs/EmailJob.php
@@ -68,12 +68,15 @@ class EmailJob implements ShouldQueue
         $postAction = $this->payload['postAction'];
         $module = ! empty($this->payload['module']) ? $this->payload['module'] : '';
         $replyTo = ! empty($this->payload['replyTo']) ? $this->payload['replyTo'] : '';
+        $cc = ! empty($this->payload['cc']) ? $this->payload['cc'] : [];
+        $bcc = ! empty($this->payload['bcc']) ? $this->payload['bcc'] : [];
+
 
         // SEND EMAIL
         $messageId = 0;
         try {
             \Log::info('WORKFLOW - Creating SES Request');
-            $messageId = SES::createRequest($from, $subject, $emailTemplate, $this->payload['payload'], $plainEmailTemplate, $jobWorkflowId, $replyTo);
+            $messageId = SES::createRequest($from, $subject, $emailTemplate, $this->payload['payload'], $plainEmailTemplate, $jobWorkflowId, $replyTo, '', '', $cc, $bcc);
             \Log::info('WORKFLOW - SES Request created with Message ID: '.$messageId);
             WorkflowLog::where([
                 'job_workflow_id' => $jobWorkflowId,

--- a/src/Services/AWS/SES.php
+++ b/src/Services/AWS/SES.php
@@ -34,14 +34,14 @@ class SES
         return new SesV2Client($awsConfig);
     }
 
-    public static function createRequest($from, $subject, $emailTemplate, $payload, $plainEmailTemplate, $jobWorkflowId, $replyTo = [], $configurationSetName = '', $tenant = '')
+    public static function createRequest($from, $subject, $emailTemplate, $payload, $plainEmailTemplate, $jobWorkflowId, $replyTo = [], $configurationSetName = '', $tenant = '', $cc = [], $bcc = [])
     {
         $isRequireBulkEmailRequest = count($payload) > 1 ? true : false;
         try {
             if ($isRequireBulkEmailRequest) {
-                $messageId = self::sendBulkEmail($from, $subject, $emailTemplate, $payload, $plainEmailTemplate, $jobWorkflowId, $replyTo, $configurationSetName, $tenant);
+                $messageId = self::sendBulkEmail($from, $subject, $emailTemplate, $payload, $plainEmailTemplate, $jobWorkflowId, $replyTo, $configurationSetName, $tenant,$cc, $bcc);
             } else {
-                $messageId = self::sendEmail($from, $subject, $emailTemplate, last($payload), $plainEmailTemplate, $jobWorkflowId, $replyTo, $configurationSetName, $tenant);
+                $messageId = self::sendEmail($from, $subject, $emailTemplate, last($payload), $plainEmailTemplate, $jobWorkflowId, $replyTo, $configurationSetName, $tenant, $cc, $bcc);
             }
         } catch (\Exception $e) {
             throw new \Exception('Error sending email: '.$e->getMessage());
@@ -50,7 +50,7 @@ class SES
         return $messageId;
     }
 
-    public static function sendBulkEmail($from, $subject, $htmlContent, $payload, $textContent = '', $jobWorkflowId = 0, $replyTo = [], $configurationSetName = '', $tenant = '')
+    public static function sendBulkEmail($from, $subject, $htmlContent, $payload, $textContent = '', $jobWorkflowId = 0, $replyTo = [], $configurationSetName = '', $tenant = '', $cc = [], $bcc = [])
     {
         try {
             $sesClient = self::getSesClient();
@@ -83,6 +83,8 @@ class SES
             $bulkEmailEntries[] = [
                 'Destination' => [
                     'ToAddresses' => (array) $item['email'],
+                    ...($cc ? ['CcAddresses' => (array) $cc] : []),
+                    ...($bcc ? ['BccAddresses' => (array) $bcc] : []),
                 ],
                 'ReplacementEmailContent' => [
                     'ReplacementTemplate' => [
@@ -135,7 +137,7 @@ class SES
         }
     }
 
-    public static function sendEmail($from, $subject, $htmlContent, $payload, $textContent = '', $jobWorkflowId = 0, $replyTo = [], $configurationSetName = '', $tenant = '')
+    public static function sendEmail($from, $subject, $htmlContent, $payload, $textContent = '', $jobWorkflowId = 0, $replyTo = [], $configurationSetName = '', $tenant = '', $cc = [], $bcc = [])
     {
         try {
             $sesClient = self::getSesClient();
@@ -181,6 +183,8 @@ class SES
                 ...(! empty($configurationSetName) ? ['ConfigurationSetName' => $configurationSetName] : []),
                 'Destination' => [
                     'ToAddresses' => (array) $recipient,
+                    ...($cc ? ['CcAddresses' => (array) $cc] : []),
+                    ...($bcc ? ['BccAddresses' => (array) $bcc] : []),
                 ],
                 'Content' => [
                     'Template' => [

--- a/src/Services/WorkflowActions/Helpers/Email/PrepareEmailData.php
+++ b/src/Services/WorkflowActions/Helpers/Email/PrepareEmailData.php
@@ -46,6 +46,8 @@ class PrepareEmailData
             'payload' => [],
             'from' => $from,
             'replyTo' => ! empty($this->emailInformation['replyTo']) ? explode(',', $this->emailInformation['replyTo']) : [],
+            'cc' => ! empty($this->payload['actionPayload']['cc']) ? array_values(array_filter(array_map('trim', explode(',', $this->payload['actionPayload']['cc'])))) : [],
+            'bcc' => ! empty($this->payload['actionPayload']['bcc']) ? array_values(array_filter(array_map('trim', explode(',', $this->payload['actionPayload']['bcc'])))) : [],
             'postAction' => $this->payload['postAction'] ?? '',
             'actionPayload' => $this->payload['actionPayload'] ?? [],
         ];


### PR DESCRIPTION
# Description
Enhanced workflow email functionality by adding support for CC and BCC recipients. Emails will include CC and BCC only when respective data is provided.

# Context
Previously, workflow emails were limited to primary recipients only. This update ensures that CC and BCC recipients are handled dynamically based on availability of data.

# DB Changes
- Migration: No
- Seeder: No

# Testing Done
- Verified emails are sent with CC when data is available
- Verified emails are sent with BCC when data is available
- Confirmed no CC/BCC is added when fields are empty
- Tested existing email flow remains unaffected