### PR TITLE
[Bug-Fix] Skip workflow when record is missing or parsed data is empty (ODS-11241)

### DIFF
--- a/src/Services/DispatchWorkflowService.php
+++ b/src/Services/DispatchWorkflowService.php
@@ -375,7 +375,12 @@ class DispatchWorkflowService
                         }
 
                         $parsedData = array_merge($parsedData, $placeHolderWithValues);
+                        $hasAtLeastOneValue = ! empty(array_filter($parsedData, fn ($v) => $v !== null && $v !== '' && $v !== false && $v !== 'null'));
 
+                        if ($this->recordIdentifier && ! empty($parsedData) && ! $hasAtLeastOneValue) {
+                            \Log::warning('WORKFLOW -  Data unavailable or all required fields are empty');
+                            break 2;
+                        }
                         if ($actionType == 'WEB_HOOK') {
                             $data = $this->generatePayloadFromParsedData($parsedData);
                         } else {


### PR DESCRIPTION
# Description
Ensures that the workflow does not proceed further if the record does not exist for the given identifier.
ODS-[11241](https://taurus-llc.atlassian.net/browse/ODS-11241)

# Context
Previously, the workflow continued execution even when no record was found, which could lead to invalid processing.

# Testing 
   Done

# DB Changes
   * No changes