### PR TITLE
[Feature] Add fillable entries for Nova tenant_id system (ODS-11600)

### DIFF
--- a/src/Models/JobWorkflow.php
+++ b/src/Models/JobWorkflow.php
@@ -20,6 +20,7 @@ class JobWorkflow extends Model
     public const STATUS_FAILED = 'FAILED';
 
     protected $fillable = [
+        'tenant_id',
         'workflow_id',
         'batch_id',
         'status',

--- a/src/Models/JobWorkflow.php
+++ b/src/Models/JobWorkflow.php
@@ -18,7 +18,7 @@ class JobWorkflow extends Model
     public const STATUS_COMPLETED = 'COMPLETED';
 
     public const STATUS_FAILED = 'FAILED';
-
+    //tenant_id is for Nova, it is ignored for odyssey
     protected $fillable = [
         'tenant_id',
         'workflow_id',

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -11,7 +11,7 @@ class Workflow extends Model
     use SoftDeletes;
 
     protected $table;
-
+    //tenant_id is for Nova, it is ignored for odyssey
     protected $fillable = [
         'tenant_id',
         'module',

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -13,6 +13,7 @@ class Workflow extends Model
     protected $table;
 
     protected $fillable = [
+        'tenant_id',
         'module',
         'name',
         'description',

--- a/src/Models/WorkflowAction.php
+++ b/src/Models/WorkflowAction.php
@@ -10,7 +10,7 @@ class WorkflowAction extends Model
     use SoftDeletes;
 
     protected $table;
-
+    //tenant_id is for Nova, it is ignored for odyssey
     protected $fillable = [
         'tenant_id',
         'condition_id',

--- a/src/Models/WorkflowAction.php
+++ b/src/Models/WorkflowAction.php
@@ -12,6 +12,7 @@ class WorkflowAction extends Model
     protected $table;
 
     protected $fillable = [
+        'tenant_id',
         'condition_id',
         'payload',
     ];

--- a/src/Models/WorkflowCondition.php
+++ b/src/Models/WorkflowCondition.php
@@ -10,8 +10,12 @@ class WorkflowCondition extends Model
     use SoftDeletes;
 
     protected $table;
-
-    protected $fillable = ['tenant_id', 'workflow_id', 'conditions'];
+    //tenant_id is for Nova, it is ignored for odyssey
+    protected $fillable = [
+        'tenant_id',
+        'workflow_id',
+        'conditions'
+     ];
 
     protected $casts = [
         'conditions' => 'json',

--- a/src/Models/WorkflowCondition.php
+++ b/src/Models/WorkflowCondition.php
@@ -11,7 +11,7 @@ class WorkflowCondition extends Model
 
     protected $table;
 
-    protected $fillable = ['workflow_id', 'conditions'];
+    protected $fillable = ['tenant_id', 'workflow_id', 'conditions'];
 
     protected $casts = [
         'conditions' => 'json',

--- a/src/Models/WorkflowLog.php
+++ b/src/Models/WorkflowLog.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class WorkflowLog extends Model
 {
+    //tenant_id is for Nova, it is ignored for odyssey
     protected $fillable = [
         'tenant_id',
         'workflow_id',

--- a/src/Models/WorkflowLog.php
+++ b/src/Models/WorkflowLog.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 class WorkflowLog extends Model
 {
     protected $fillable = [
+        'tenant_id',
         'workflow_id',
         'record_identifier',
         'module',


### PR DESCRIPTION
# Description
This adds "tenant_id" to relevant $fillable lists to allow it to be exposed on the Nova system. This won't effect tables that don't have tenant_id and thus won't affect any behavior on the main system.
# Context
https://taurus-llc.atlassian.net/browse/ODS-11600
https://github.com/implevision/odyssey-nova-back/pull/96
# Testing Done
local