### PR TITLE
[Bug-Fix] Add PHPDoc properties to models (ODS-11428)

### DIFF
--- a/src/Models/JobWorkflow.php
+++ b/src/Models/JobWorkflow.php
@@ -5,6 +5,14 @@ namespace Taurus\Workflow\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\SerializesModels;
 
+/**
+ * @property int|null $workflow_id
+ * @property int|null $batch_id
+ * @property string|null $status
+ * @property int|null $total_no_of_records_to_execute
+ * @property int|null $total_no_of_records_executed
+ * @property array|null $response
+ */
 class JobWorkflow extends Model
 {
     use SerializesModels;
@@ -18,7 +26,8 @@ class JobWorkflow extends Model
     public const STATUS_COMPLETED = 'COMPLETED';
 
     public const STATUS_FAILED = 'FAILED';
-    //tenant_id is for Nova, it is ignored for odyssey
+
+    // tenant_id is for Nova, it is ignored for odyssey
     protected $fillable = [
         'tenant_id',
         'workflow_id',

--- a/src/Models/WorkflowLog.php
+++ b/src/Models/WorkflowLog.php
@@ -4,9 +4,20 @@ namespace Taurus\Workflow\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property int|null $workflow_id
+ * @property int|null $record_identifier
+ * @property string|null $module
+ * @property string|null $status
+ * @property int|null $job_workflow_id
+ * @property string|null $action_type
+ * @property int|null $action_track_id
+ * @property string|null $error
+ * @property \Carbon\Carbon|null $created_at
+ */
 class WorkflowLog extends Model
 {
-    //tenant_id is for Nova, it is ignored for odyssey
+    // tenant_id is for Nova, it is ignored for odyssey
     protected $fillable = [
         'tenant_id',
         'workflow_id',


### PR DESCRIPTION
# Description
Add @property annotations to JobWorkflow and WorkflowLog models to document common attributes (e.g. workflow_id, batch_id, status, counts, response, record_identifier, module, action_type, created_at) which improves static analysis and IDE autocompletion. Also normalize a minor comment spacing in both files.
# Context
Add PHPDoc properties to models
# DB Changes
No
# Testing Done
Locally & UAT