### PR TITLE
[Bug-Fix] Multilevel auth token extraction for webhook (ODS-11631)

### DIFF
--- a/src/Services/WorkflowActions/WebhookAction.php
+++ b/src/Services/WorkflowActions/WebhookAction.php
@@ -162,45 +162,51 @@ class WebhookAction extends AbstractWorkflowAction
         }
     }
 
-    private function replacePlaceholders($input, $placeholders, $replaceWithEmptySpaceIfNotAvailable = false)
+    private function replacePlaceholders($input, $placeholders, $replaceWithEmptySpaceIfNotAvailable = false, $resolveNested = false)
     {
         if (is_array($input)) {
-            return array_map(function ($item) use ($placeholders, $replaceWithEmptySpaceIfNotAvailable) {
-                return $this->replacePlaceholders($item, $placeholders, $replaceWithEmptySpaceIfNotAvailable);
+            return array_map(function ($item) use ($placeholders, $replaceWithEmptySpaceIfNotAvailable, $resolveNested) {
+                return $this->replacePlaceholders($item, $placeholders, $replaceWithEmptySpaceIfNotAvailable, $resolveNested);
             }, $input);
         }
 
-        return preg_replace_callback('/{{\s*(.*?)\s*}}/', function ($matches) use ($placeholders, $replaceWithEmptySpaceIfNotAvailable) {
+        return preg_replace_callback('/{{\s*(.*?)\s*}}/', function ($matches) use ($placeholders, $replaceWithEmptySpaceIfNotAvailable, $resolveNested) {
             $placeholder = $matches[1];
-
             $defaultValue = $replaceWithEmptySpaceIfNotAvailable ? '' : '{{'.$placeholder.'}}';
+
+            if ($resolveNested && is_array($placeholders)) {
+                $value = $this->resolveNestedValue($placeholders, $placeholder);
+
+                return $value !== null ? $value : $defaultValue;
+            }
 
             return isset($placeholders[$placeholder]) ? $placeholders[$placeholder] : $defaultValue;
         }, $input);
+    }
+
+    private function resolveNestedValue(array $data, string $key): mixed
+    {
+        if (array_key_exists($key, $data)) {
+            return $data[$key];
+        }
+
+        $keys = explode('.', $key);
+        $value = $data;
+        foreach ($keys as $k) {
+            if (! is_array($value) || ! array_key_exists($k, $value)) {
+                return null;
+            }
+            $value = $value[$k];
+        }
+
+        return $value;
     }
 
     private function updateHeadersWithAuthResponse($webhookRequestHeaders)
     {
         $payload = $this->getPayload();
         $authResponse = $payload['authResponse'] ?? [];
-        $flattenedAuthResponse = is_array($authResponse) ? $this->flattenArray($authResponse) : $authResponse;
 
-        return $this->replacePlaceholders($webhookRequestHeaders, $flattenedAuthResponse);
-    }
-
-    private function flattenArray(array $array, string $prefix = ''): array
-    {
-        $result = [];
-        foreach ($array as $key => $value) {
-            $flatKey = $prefix !== '' ? $prefix.'.'.$key : (string) $key;
-            if (is_array($value)) {
-                $result[$flatKey] = $value;
-                $result = array_merge($result, $this->flattenArray($value, $flatKey));
-            } else {
-                $result[$flatKey] = $value;
-            }
-        }
-
-        return $result;
+        return $this->replacePlaceholders($webhookRequestHeaders, $authResponse, false, true);
     }
 }

--- a/src/Services/WorkflowActions/WebhookAction.php
+++ b/src/Services/WorkflowActions/WebhookAction.php
@@ -181,10 +181,26 @@ class WebhookAction extends AbstractWorkflowAction
 
     private function updateHeadersWithAuthResponse($webhookRequestHeaders)
     {
-        // GET UPDATED PAYLOAD WITH AUTH RESPONSE
         $payload = $this->getPayload();
+        $authResponse = $payload['authResponse'] ?? [];
+        $flattenedAuthResponse = is_array($authResponse) ? $this->flattenArray($authResponse) : $authResponse;
 
-        // TODO: add support for multilevel auth token extraction.
-        return $this->replacePlaceholders($webhookRequestHeaders, $payload['authResponse'] ?? []);
+        return $this->replacePlaceholders($webhookRequestHeaders, $flattenedAuthResponse);
+    }
+
+    private function flattenArray(array $array, string $prefix = ''): array
+    {
+        $result = [];
+        foreach ($array as $key => $value) {
+            $flatKey = $prefix !== '' ? $prefix.'.'.$key : (string) $key;
+            if (is_array($value)) {
+                $result[$flatKey] = $value;
+                $result = array_merge($result, $this->flattenArray($value, $flatKey));
+            } else {
+                $result[$flatKey] = $value;
+            }
+        }
+
+        return $result;
     }
 }


### PR DESCRIPTION
# Description
Multilevel auth token extraction for webhook : [ODS-11631](https://taurus-llc.atlassian.net/browse/ODS-11631)

# Context
Previously, the webhook basic auth response only supported single-level (flat) key access for placeholder replacement in headers. If the auth API returned a nested JSON response (e.g., `{"data": {"access_token": "xyz"}}`), placeholders like `{{data.access_token}}` would not resolve.

## What Changed

### `resolveNestedValue(array $data, string $key): mixed`
A new private method that resolves a placeholder key against a nested array using dot notation.
- First checks for an **exact key match** (`array_key_exists`) — preserves all existing flat-key behaviour.
- If no exact match, splits the key by `.` and **traverses the array level by level**.
- Returns `null` if any segment is missing, which falls back to the default placeholder value.

```php
// Auth response from API:
// { "status": true, "data": { "access_token": "xyz", "token_type": "bearer" } }

{{status}}              → true       (exact key match at root)
{{data.access_token}}   → "xyz"      (dot-notation traversal: data → access_token)
{{data.token_type}}     → "bearer"   (dot-notation traversal: data → token_type)
{{unknown}}             → {{unknown}} (not found, falls back to default)
```

### `replacePlaceholders` — `$resolveNested = false` flag added
A new optional 4th parameter `$resolveNested` (default `false`) was added. **All existing calls omit this parameter**, so they receive `false` and behave exactly as before — zero impact on current code.

Only `updateHeadersWithAuthResponse` passes `true`, scoping the nested resolution exclusively to auth response header replacement.

## Proof: Existing Calls Are Not Affected

| Location | Call | `$resolveNested` | Behaviour |
|---|---|---|---|
| Line 147 | UUID replacement in headers | `false` (default) | Unchanged |
| Line 154 | URL placeholder replacement | `false` (default) | Unchanged |
| Line 155 | Payload placeholder replacement | `false` (default) | Unchanged |
| `updateHeadersWithAuthResponse` | Auth response → headers | `true` (explicit) | New nested resolution |

The `flattenArray` approach from the previous commit is removed — dot-notation traversal is safer as it avoids key collision risks when an API returns keys that literally contain dots.

# Testing Done
Yes

# DB Changes
No

[ODS-11631]: https://taurus-llc.atlassian.net/browse/ODS-11631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ