### PR TITLE
[Feature] Client API key placeholders for webhook basic auth (ODS-11631)

### DIFF
--- a/src/Services/WorkflowActions/WebhookAction.php
+++ b/src/Services/WorkflowActions/WebhookAction.php
@@ -44,13 +44,24 @@ class WebhookAction extends AbstractWorkflowAction
             return [];
         }
 
+        // Resolve placeholders (e.g. {{api_key}}, {{api_secret}}, {{X-Client-key}}) in
+        // authHeaders and authParams before the auth request is made.
+        $data = $this->getData();
+        if (! empty($data)) {
+            $firstRecord = reset($data);
+            $this->updatePayload('authHeaders', $this->replacePlaceholders($payload['authHeaders'] ?? [], $firstRecord, true));
+            $this->updatePayload('authParams', $this->replacePlaceholders($payload['authParams'] ?? [], $firstRecord, true));
+            $payload = $this->getPayload();
+        }
+
         $accessTokenExpiryTimeInSeconds = $payload['accessTokenExpiryTimeInSeconds'];
         switch ($authType) {
             case 'BASIC_AUTH':
                 $basicAuthService = new BasicAuthService;
                 $authUrl = $payload['authUrl'];
-                // Create unique cache key per tenant and baseUrl, in case multiple webhooks are used
-                $cacheKey = 'BASIC_AUTH_TOKEN_'.md5($authUrl);
+                // Cache key includes a hash of resolved auth params so different clients
+                // with the same authUrl get separate cache entries.
+                $cacheKey = 'BASIC_AUTH_TOKEN_'.md5($authUrl.json_encode($payload['authParams'] ?? []).json_encode($payload['authCredentials'] ?? []));
                 $authResponse = Cache::remember($cacheKey, $accessTokenExpiryTimeInSeconds, function () use ($payload, $basicAuthService) {
                     \Log::info('WORKFLOW - cache hit missed, fetching new BASIC_AUTH token');
 
@@ -87,6 +98,8 @@ class WebhookAction extends AbstractWorkflowAction
             $payload['webhookRequestPayload'] ?? [],
             $payload['webhookRequestHeaders'] ?? [],
             $payload['webhookRequestUrl'] ?? '',
+            $payload['authHeaders'] ?? [],
+            $payload['authParams'] ?? [],
         ];
 
         $placeholders = [];
@@ -149,12 +162,12 @@ class WebhookAction extends AbstractWorkflowAction
         $webhookRequestHeaders = $this->updateHeadersWithAuthResponse($webhookRequestHeaders);
 
         if ($data) {
-            preg_match_all('/{{\s*(.*?)\s*}}/', $webhookRequestUrl, $webhookRequestUrlPlaceholderMatches);
             foreach ($data as $placeHolderData) {
-                $requestUrl = $this->replacePlaceholders($webhookRequestUrl, $placeHolderData, true);
+                $requestHeaders = $this->replacePlaceholders($webhookRequestHeaders, $placeHolderData, true);
+                $requestUrl     = $this->replacePlaceholders($webhookRequestUrl, $placeHolderData, true);
                 $requestPayload = $this->replacePlaceholders($webhookRequestPayload, $placeHolderData, true);
                 try {
-                    Http::makeRequest($webhookRequestMethod, $requestUrl, $webhookRequestHeaders, $requestPayload);
+                    Http::makeRequest($webhookRequestMethod, $requestUrl, $requestHeaders, $requestPayload);
                 } catch (\Exception $e) {
                     throw new \Exception('Webhook execution failed: '.$e->getMessage());
                 }


### PR DESCRIPTION
# Description
Support `{{X-Client-key}}`, `{{api_key}}`, and `{{api_secret}}` as placeholders in webhook `authHeaders` and `authParams`: [ODS-11600](https://taurus-llc.atlassian.net/browse/ODS-11600)

# Context
Previously, placeholder replacement for webhook actions only applied to `webhookRequestPayload`, `webhookRequestHeaders`, and `webhookRequestUrl`. The `authHeaders` and `authParams` fields used in basic auth were passed as-is to `BasicAuthService`, so client-specific credentials could not be injected dynamically. Additionally, `webhookRequestHeaders` was not being replaced with per-record data inside the execution loop.

## What Changed

### `handleAuthorization()` — placeholder resolution before auth call
Before calling `BasicAuthService::authenticate()`, `authHeaders` and `authParams` are now passed through `replacePlaceholders()` using the first data record. This allows placeholders like `{{api_key}}`, `{{api_secret}}`, and `{{X-Client-key}}` to be resolved from client-supplied data before the auth HTTP request is made.

### `handleAuthorization()` — per-client cache key
The BASIC_AUTH cache key now includes a hash of the resolved `authParams` and `authCredentials` in addition to `authUrl`. This prevents different clients sharing the same `authUrl` but different credentials from receiving each other's cached tokens.

### `getListOfRequiredData()` — scan authHeaders and authParams
`authHeaders` and `authParams` are now included in the placeholder scan so the workflow correctly declares `X-Client-key`, `api_key`, and `api_secret` as required data fields.

### `execute()` — fix missing webhookRequestHeaders replacement per record
`webhookRequestHeaders` was only having `{{UUID}}` and auth response placeholders replaced, but was never passed through `replacePlaceholders()` with per-record data inside the `foreach` loop. This meant placeholders like `{{X-Client-key}}` in request headers would never be filled. Fixed by resolving headers per record inside the loop (same pattern as URL and payload).

Also removed the unused `preg_match_all` call on `webhookRequestUrl` that was leftover inside the loop.

# Testing Done
Yes

# DB Changes
No

[ODS-11600]: https://taurus-llc.atlassian.net/browse/ODS-11600