### PR TITLE
[Bug-Fix] Fix date formatting issue when date value is empty (ODS-10994)

### DIFF
--- a/src/Consumer/Taurus/Helper.php
+++ b/src/Consumer/Taurus/Helper.php
@@ -48,6 +48,10 @@ class Helper
 
     public static function formatDate($dateToFormat)
     {
+        if (empty($dateToFormat)) {
+            return null;
+        }
+        
         return Carbon::parse($dateToFormat)->format('m/d/Y');
     }
 


### PR DESCRIPTION
# Description
Updated the `formatDate` method to return `null` when the provided date value is empty, preventing invalid date formatting and related errors.

# Context
- Added a check for empty date values in `formatDate`.
- Returns `null` instead of attempting to format an empty date.
- Prevents invalid date formatting and unexpected behavior.

# DB Changes
- No database changes.

# Testing Done
Locally Done 