### PR TITLE
[Feature] Add WITH_IN to Execution Event Incident Validation (ODS-11809)

### DIFF
--- a/src/Http/Rules/ValidDateTimeInfo.php
+++ b/src/Http/Rules/ValidDateTimeInfo.php
@@ -25,7 +25,7 @@ class ValidDateTimeInfo implements ValidationRule
             if (! $certainDateTime) {
                 $allowedValues = [
                     'executionFrequencyType' => ['DAY', 'MONTH', 'YEAR'],
-                    'executionEventIncident' => ['AFTER', 'BEFORE'],
+                    'executionEventIncident' => ['AFTER', 'BEFORE', 'WITH_IN'],
                     // 'executionEvent' => ['CREATION', 'EXPIRATION'],
                     'recurringFrequency' => ['ONCE', 'MONTH', 'YEAR'],
                 ];


### PR DESCRIPTION
# Description
Added support for the `WITH_IN` execution event in the `executionEventIncident` validation rule.

# Context
The workflow now accepts `WITH_IN` as a valid execution event along with the existing `AFTER` and `BEFORE` values.

# DB Changes
N/A

# Testing Done
- Verified that `WITH_IN` is now accepted as a valid execution event.
